### PR TITLE
 Fix windows line break failing single test

### DIFF
--- a/tests/Feature/AustraliaPostTest.php
+++ b/tests/Feature/AustraliaPostTest.php
@@ -456,8 +456,16 @@ it('can handle generic client exceptions', function () {
         client: $httpClient,
     ));
 
-    $this->app->make(Factory::class)
-        ->driver(AusPost::IDENTIFIER)
-        ->find('I3XX00123456');
-})->throws(ClientException::class, 'Client error: `GET /shipping/v1/track?tracking_ids=I3XX00123456` resulted in a `419 ` response:
-[]');
+    $exception = null;
+    try {
+        $this->app->make(Factory::class)
+            ->driver(AusPost::IDENTIFIER)
+            ->find('I3XX00123456');
+    } catch (ClientException $exception) {
+    }
+
+    expect($exception)->toBeInstanceOf(ClientException::class)
+        ->and($exception->getCode())->toBe(419)
+        ->and(trim(preg_replace('/[\s\n\r]+/', ' ', $exception->getMessage())))
+            ->toBe('Client error: `GET /shipping/v1/track?tracking_ids=I3XX00123456` resulted in a `419 ` response: []');
+});


### PR DESCRIPTION
Fixes the issue where only the Windows test was failing for the final test that asserts ClientExceptions are still thrown, due to Windows line breaks being different to what was written in the expected string.

For this one test I have standardised all whitespace and have trimmed the exception message.

- [x] I have read the **[CONTRIBUTING](https://github.com/parceltrap/driver-auspost/blob/main/.github/CONTRIBUTING.md)** document.
